### PR TITLE
Fix typo in poetry command

### DIFF
--- a/30_languages/PackageManager/python/02_poetry.md
+++ b/30_languages/PackageManager/python/02_poetry.md
@@ -45,7 +45,7 @@ poetry shell
 poetry run python -m unittest ~~~
 
 # pyproject.tomlの検証
-portry check
+poetry check
 
 # pyproject.tomlから一括インストール。poetry.lockがあればそれを参考にする
 poetry install


### PR DESCRIPTION
## Summary
- correct a typo from `portry check` to `poetry check`

## Testing
- `git status --short`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6881b5d5f364832bb5d069aaf827a4bd)