### PR TITLE
Fix Python example snippet

### DIFF
--- a/30_languages/03_python_ruby.md
+++ b/30_languages/03_python_ruby.md
@@ -211,12 +211,11 @@ nil
 
 ```python
 # 定義
-def hello:
+def hello():
     print("HELLO")
 
 def introduction(name):
-    print("私は%sです。" % name)
-    print("私は#{name}です。")
+    print(f"私は{name}です。")
 
 def add(x, y):
     return x + y


### PR DESCRIPTION
## Summary
- fix `hello` function in Python vs Ruby documentation
- use f-string in the introduction example

## Testing
- `git status --short`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_687f1ece36a4832b89afce486036df46)