### PR TITLE
Fix logging syntax in Node.js HTTP example

### DIFF
--- a/30_languages/09_nodejs.md
+++ b/30_languages/09_nodejs.md
@@ -615,7 +615,7 @@ let request = http.request(url, options, (response) => {
   response.pipe(process.stdout);
 });
 request.on("error", (err) => {
-  console.log.(err.message)
+  console.log(err.message)
 });
 console.log(request);
 request.end(data);


### PR DESCRIPTION
### Motivation
- Fix a syntax error in the Node.js POST request example where `console.log.(err.message)` would cause a runtime error.
- Ensure the example code block is valid and runnable as shown in documentation.
- Improve accuracy of examples to prevent confusion for readers.

### Description
- Replace `console.log.(err.message)` with `console.log(err.message)` in `30_languages/09_nodejs.md`.
- The change is localized to the POST request error handler in the Node.js examples and does not alter surrounding content.
- No other code logic or examples were modified.

### Testing
- No automated tests were run because this is a docs-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69651cec01ec832b8c55b6aafdbc9d5e)